### PR TITLE
Option to provide initial template; improvements to options handling; warning regarding NaN data; efficient trial loop breaking

### DIFF
--- a/compute_nerds.m
+++ b/compute_nerds.m
@@ -37,8 +37,16 @@ y = vec(y) - min(vec(y));    % vectorize input signal
 y = zero_pad(y, opts.L);  % zero padding to prevent circular shift
 N = length(y);               % original length of input signal (with padding)
 
-% create initial atom/template (length L)
-gen_atom = exp(-[0:1:N-1]'./(L/4));
+if (isfield(opts, 'template0'))
+   % use estimated initial template
+   gen_atom = zeros(N, 1);
+   gen_atom(1:numel(opts.template0)) = opts.template0(:);
+
+else   
+   % create initial atom/template (length L)
+   gen_atom = exp(-(0:1:N-1)'./(L/4));
+end
+
 gen_atom = gen_atom/norm(gen_atom);         % normalized
 gen_atom_freq = 1/sqrt(N)*fft(gen_atom);    % frequency normalized
 initial_atom = gen_atom;

--- a/compute_nerds.m
+++ b/compute_nerds.m
@@ -1,12 +1,14 @@
 function [gen_atom_out, spike_idx, x_hat_out, e_hat_out] = compute_nerds(y, opts)
 %COMPUTE_NERDS
 %
-%input  y - input 1-D fluorescent signal (element should be all positive)
-%       opts.L - approximate length of template (gen_atom)
-%       opts.numTrials - number of iterations that you want to run
-%       opts.thresh - thershold parameter to suppress outlier spikes
-%       opts.wsize - window size to sum close spikes together in window size
-%       opts.verbose - true/false 
+%input  y - input 1-D fluorescent signal (element should be all positive, with no NaNs)
+%       opts - Structure defining options (all are optional)
+%           opts.L - approximate length of template (gen_atom)
+%           opts.template0 - initial template estimate
+%           opts.numTrials - number of iterations that you want to run
+%           opts.thresh - thershold parameter to suppress outlier spikes
+%           opts.wsize - window size to sum close spikes together in window size
+%           opts.verbose - true/false: Set verbosity of solver
 %
 %output gen_atom_mat - all learned template from trial one to numTrials
 %       spike_idx - set of spike occurence index
@@ -17,30 +19,39 @@ if nargin < 2
     opts = struct;
 end
 
-if ~isfield(opts, 'L')
-    L = input('\nwhat is the approximated length of template?: ');
-    opts.L = L;
-end
 if ~isfield(opts, 'numTrials')  opts.numTrials = 10;    end
 if ~isfield(opts, 'thresh')     opts.thresh = 0.1;      end
 if ~isfield(opts, 'wsize')      opts.wsize = 10;        end
 if ~isfield(opts, 'verbose')    opts.verbose = false;   end
+
+if ~isfield(opts, 'L')
+   if isfield(opts, 'template0')
+      opts.L = numel(opts.template0);
+   else
+      opts.L = input('\nwhat is the approximated length of template?: ');
+   end
+end
 
 % get some variable that use frequently
 L = opts.L;
 wsize = opts.wsize;
 thresh = opts.thresh;
 
+% - Check input vector for NaNs
+if any(isnan(y))
+   error('*** compute_nerds: NaNs found in input data.');
+end
+
 % vectorize and padding input
 N_orig = length(y);
 y = vec(y) - min(vec(y));    % vectorize input signal
-y = zero_pad(y, opts.L);  % zero padding to prevent circular shift
+y = zero_pad(y, 20*opts.L);  % zero padding to prevent circular shift
 N = length(y);               % original length of input signal (with padding)
 
 if (isfield(opts, 'template0'))
    % use estimated initial template
    gen_atom = zeros(N, 1);
-   gen_atom(1:numel(opts.template0)) = opts.template0(:);
+   gen_atom(1:L) = opts.template0(1:L);
 
 else   
    % create initial atom/template (length L)
@@ -59,13 +70,33 @@ e_hat_mat = zeros(N, opts.numTrials);
 
 
 for trials = 1:opts.numTrials
-    
+
+   % - Display progress
+   if (opts.verbose)
+      fprintf('NERDS: Trial %d...\n', trials);
+   end
+   
     opts_spg = spgSetParms('verbosity', opts.verbose);
     dict_fun = @(x,mode) dict(x, mode, N, gen_atom_freq);
     
     % non-negativity constraint on coefficients
     x_hat = spg_bp_NN(dict_fun, y, 1:N, opts_spg);
     x_hat(N-L:N) = 0; % set last L coefficient to zeros
+
+    % Stop if we reached the last trial
+    if (trials >= opts.numTrials)
+       if (wsize > 1)
+          x_hat_A = peak_sum(x_hat, wsize, thresh); % added function to sum peak in some window size
+          spike_idx{trials} = find(x_hat_A); %#ok<AGROW>
+       else
+          spike_idx{trials} = find(x_hat); %#ok<AGROW>
+       end
+       
+       gen_atom_mat = gen_atom(1:N-L);
+       x_hat_mat = x_hat(1:N-L);
+       e_hat_mat = x_hat(N+1:end);
+       break;
+    end
     
     % update dictionary
     [gen_atom, spk_idx] = gen_new_atom(y, x_hat, N, L, wsize, thresh);
@@ -75,8 +106,7 @@ for trials = 1:opts.numTrials
     x_hat_mat(:,trials) = x_hat(1:N-L);
     e_hat_mat(:,trials) = x_hat(N+1:end);
     
-    spike_idx{trials} = spk_idx;
-    fprintf('Number of trials: %d\n', trials);
+    spike_idx{trials} = spk_idx; %#ok<AGROW>
     
     % stopping criteria if template converge
     if norm(gen_atom_mat(:,trials+1)-gen_atom_mat(:,trials))<1e-8
@@ -97,7 +127,9 @@ gen_atom_out = gen_atom_mat(1:N_orig,:);
 x_hat_out = x_hat_mat(1:N_orig,:);
 e_hat_out = e_hat_mat(1:N_orig,:);
 
-fprintf('Finish NERDS!\n');
+if (opts.verbose)
+   fprintf('NERDS: Finished.\n');
+end
 
 end
 

--- a/example_nerds.m
+++ b/example_nerds.m
@@ -7,6 +7,7 @@ load('example_real_data')
 flo = flo - min(flo);
 % or flo = rescale(flo); will adjust signal to range 0 to 1
 peak_counts = count_peaks(ephys, flo);
+N = length(flo);
 actual_spikes = nan(N,1); 
 actual_spikes(find(peak_counts)) = 1.05*max(flo);
 
@@ -14,7 +15,6 @@ actual_spikes(find(peak_counts)) = 1.05*max(flo);
 % - if we plot fluorescent data, we can see that length of each peak has
 %   length (index) around 70
 %
-N = length(flo);
 opts.L = 70;         % length of template approximate from fluorescent signal
 opts.thresh = 0.2;   % thresholding parameter, plot x_hat_mat to estimate threshold
 opts.numTrials = 5;  % number of iteration

--- a/example_nerds.m
+++ b/example_nerds.m
@@ -7,14 +7,9 @@ load('example_real_data')
 flo = flo - min(flo);
 N = length(flo);
 % or flo = rescale(flo); will adjust signal to range 0 to 1
-<<<<<<< HEAD
 peak_counts = count_peaks(ephys, flo);
 N = length(flo);
 actual_spikes = nan(N,1); 
-=======
-peak_counts = peak_count(ephys, flo);
-actual_spikes = nan(N,1);
->>>>>>> 23775270f94052cb1267dff1ef1e45a97d302f94
 actual_spikes(find(peak_counts)) = 1.05*max(flo);
 
 %% Run compute_nerds

--- a/utilities/gen_new_atom.m
+++ b/utilities/gen_new_atom.m
@@ -10,7 +10,9 @@ end
 
 % note x = [x_A; x_B] which is spike component and baseline component
 x_hat_A = x_hat(1:N);
-x_hat_A = peak_sum(x_hat_A, wsize, thresh); % added function to sum peak in some window size
+if (wsize > 1)
+   x_hat_A = peak_sum(x_hat_A, wsize, thresh); % added function to sum peak in some window size
+end
 x_hat_B = x_hat(N+1:2*N);
 set = find(x_hat_A);
 


### PR DESCRIPTION
Hi,

I made a few improvements that you might be interested in including.
* Added the option to provide an initial template (atom) estimate, via the `opts` structure
* The value for `L` is taken from this initial template, if provided
* An error is displayed if the input data contains `NaN`s (since the solver does not work in that case)
* Early stopping on the last trial, without re-estimating the atom. This is to allow "single trial" mode, without template estimation
* Slightly improved progress display, using the `opts` structure

Best regards,
Dylan.